### PR TITLE
Bug fix in CompactIntSubset

### DIFF
--- a/src/com/nobigsoftware/dfalex/CompactIntSubset.java
+++ b/src/com/nobigsoftware/dfalex/CompactIntSubset.java
@@ -195,6 +195,5 @@ class CompactIntSubset
 		m_marksize = newsize;
 		Arrays.sort(m_usemarks, 0, m_marksize);
 		m_sorted = true;
-		assert(m_marksize == m_size);
 	}
 }


### PR DESCRIPTION
Just removed the `assert(m_marksize == m_size)` since having 2 elements that correspond to the same (4byte) word would necessarily result in `m_marksize < m_size`